### PR TITLE
Ports can get higher than 5950

### DIFF
--- a/ovirt-console
+++ b/ovirt-console
@@ -114,9 +114,6 @@ except ValueError:
 if rport < 5900:
   sys.stderr.write( "The port (" + strport + ") is an unexpected number.\n" )
   sys.exit()
-if rport > 5950:
-  sys.stderr.write( "The port (" + strport + ") is an unexpected number.\n" )
-  sys.exit()
 
 # grab the password
 try:


### PR DESCRIPTION
With many virtual machines, ports can go way higher than 5950, even over 6000. Removed the test for rport<5950.